### PR TITLE
Add dryCracker as a far easier, faster, and more optimized seed cracking program

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
             </md-input-container>
         </div>
 		<div class="collapse-content" id="content-4">
-		<p>If you play on PC, you can just import your save file, which will include your seed and total spells cast. If you play on console, you can't export your save file, so you'll need another way to find your game seed. You can use <a href="https://staticvariablejames.github.io/SeedCracker/">this program</a> to find your seed for the current ascension. I may make a newer version of this program at some point, with support for other seeded events.</p>
+		<p>If you play on PC, you can just import your save file, which will include your seed and total spells cast. If you play on console, you can't export your save file, so you'll need another way to find your game seed. You can use <a href="https://cursedsliver.github.io/dryCracker">this program</a> to find your seed for the current ascension. I may make a newer version of this program at some point, with support for other seeded events.</p>
         </div>
 		
         <p></p><b>Based on FtHoF planner v1, v2, v3, v4 by RebelKeithy, Skeezy, Eminenti, and Mylaaan. Huge thanks to them for


### PR DESCRIPTION
I've improved dry cracker to actually work on console CC using grandma types instead of grandma names which do not need hover-over and can be inputted very easily without needing to first cast spells, and it also searches the seed space much faster than the current seed cracker thanks to precomputation